### PR TITLE
39 feat 멋사 스프링 4주차 과제

### DIFF
--- a/spring/week04/seminar/src/main/java/com/likelion/seminar/controller/BoardController.java
+++ b/spring/week04/seminar/src/main/java/com/likelion/seminar/controller/BoardController.java
@@ -1,0 +1,45 @@
+package com.likelion.seminar.controller;
+
+import com.likelion.seminar.dto.BoardDTO;
+import com.likelion.seminar.service.BoardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/board")
+public class BoardController {
+
+    private final BoardService boardService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public void createBoard(@RequestBody BoardDTO boardDTO) {
+        boardService.createBoard(boardDTO);
+    }
+
+    @GetMapping("/{id}")
+    public BoardDTO getBoard(@PathVariable Long id) {
+        return boardService.getBoard(id);
+    }
+
+    @GetMapping
+    public List<BoardDTO> getBoards() {
+        return boardService.getBoards();
+    }
+
+    @PutMapping("/{id}")
+    public void updateBoard(@PathVariable Long id,
+                            @RequestBody BoardDTO boardDTO) {
+        boardService.updateBoard(id, boardDTO);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteBoard(@PathVariable Long id) {
+        boardService.deleteBoard(id);
+    }
+}

--- a/spring/week04/seminar/src/main/java/com/likelion/seminar/dto/BoardDTO.java
+++ b/spring/week04/seminar/src/main/java/com/likelion/seminar/dto/BoardDTO.java
@@ -1,0 +1,18 @@
+package com.likelion.seminar.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardDTO {
+
+    private Long id;
+
+    private String name;
+
+}

--- a/spring/week04/seminar/src/main/java/com/likelion/seminar/entity/Board.java
+++ b/spring/week04/seminar/src/main/java/com/likelion/seminar/entity/Board.java
@@ -23,11 +23,13 @@ public class Board {
 
     @OneToMany(
             fetch = FetchType.LAZY,
-            mappedBy = "board"
+            mappedBy = "board",
+            cascade = CascadeType.REMOVE,
+            orphanRemoval = true
     )
     private List<Post> posts = new ArrayList<>();
 
-    private Board(String name) {
+    public Board(String name) {
         this.name = name;
     }
 

--- a/spring/week04/seminar/src/main/java/com/likelion/seminar/service/BoardService.java
+++ b/spring/week04/seminar/src/main/java/com/likelion/seminar/service/BoardService.java
@@ -1,0 +1,77 @@
+package com.likelion.seminar.service;
+
+import com.likelion.seminar.dto.BoardDTO;
+import com.likelion.seminar.entity.Board;
+import com.likelion.seminar.repository.BoardRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BoardService {
+
+    private final BoardRepository boardRepository;
+
+    /** Board 생성 **/
+    @Transactional
+    public void createBoard(BoardDTO boardDTO) {
+        Board board = new Board(boardDTO.getName());
+
+        boardRepository.save(board);
+    }
+
+    /** 개별 Board 조회 **/
+    public BoardDTO getBoard(Long id) {
+        Board board = boardRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 게시판입니다."));
+
+        return new BoardDTO(
+                id,
+                board.getName()
+        );
+    }
+
+    /** 전체 Board 조회 **/
+    public List<BoardDTO> getBoards() {
+        List<Board> boards = boardRepository.findAll();
+
+        List<BoardDTO> boardDTOList = new ArrayList<>();
+        for (Board board : boards) {
+            boardDTOList.add(
+                    new BoardDTO(
+                            board.getId(),
+                            board.getName()
+                    )
+            );
+        }
+
+        return boardDTOList;
+    }
+
+    /** Board 수정 **/
+    @Transactional
+    public void updateBoard(Long id, BoardDTO boardDTO) {
+        Board board = boardRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 게시판입니다."));
+
+        board.setName(boardDTO.getName());
+
+        // @Transactional이 있기 때문에 save()를 호출하지 않아도 된다 !!
+        // boardRepository.save(board);
+    }
+
+    /** Board 삭제 **/
+    @Transactional
+    public void deleteBoard(Long id) {
+        Board board = boardRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 게시판입니다."));
+
+        boardRepository.delete(board);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #이슈번호 를 적어주세요. -->
#39
 
## ✨ 과제 내용
### Board 삭제 정책

저는 Board를 삭제할 때 해당 Board에 속한 Post도 모두 함께 삭제하는 정책을 선택했습니다.  ᵔ  ̫ ᵔ 
따라서 아래와 같이 엔티티를 수정하여 삭제 정책을 구현할 수 있엇습니다 ~~

```java
@OneToMany(
        fetch = FetchType.LAZY,
        mappedBy = "board",
        cascade = CascadeType.REMOVE
)
private List<Post> posts = new ArrayList<>();
```

`CascadeType.REMOVE`를 설정하여 Board 삭제 시 연관된 Post에도 삭제 작업이 전달되도록 구현했습니다 !!

다른 옵션도 함께 알아볼까염 ᵔ  ̫ ᵔ 


CascadeType에는 다음과 같은 옵션들이 있습니다.

- PERSIST : 부모 Entity 저장 시 연관 Entity도 함께 저장
- MERGE : 부모 Entity 병합 시 연관 Entity도 함께 병합
- REMOVE : 부모 Entity 삭제 시 연관 Entity도 함께 삭제
- REFRESH : 부모 Entity를 새로 조회할 때 연관 Entity도 함께 갱신
- DETACH : 부모 Entity가 영속성 컨텍스트에서 분리될 때 연관 Entity도 함께 분리
- ALL : 위의 모든 작업을 연관 Entity에 전달

`CascadeType`은 부모 Entity에 실행한 저장, 수정, 삭제 등의 작업을 연관된 자식 Entity에도 전달할지 결정하는 옵션입니다. 
이번 과제에서는 Board의 삭제 작업을 Post에도 전달하기 위해 `CascadeType.REMOVE`를 사용한 것입니다 !!!

삭제 정책은 이외에도 삭제 전에 해당 Board를 참조하는 Post가 있는지 검사하여 연관된 Post가 존재하면 Board 삭제를 제한하거나, Post의 Board 연결을 해제한 뒤 (`Post.board = null` 로 바꿔 연결 해제 !!) Board만 삭제하는 방식으로 구현할 수 있습니다.


### BoardDTO 설계

그 다음으로 게시판 요청과 응답에 사용할 `BoardDTO` 를 구현했습니다.

- `id`: 게시판 식별 번호
- `name`: 게시판 이름

```java
public class BoardDTO {

    private Long id;

    private String name;
}
```

### Board CRUD 구현

마지막으로 `BoardController` 에서 HTTP 요청을 받고, `BoardService` 에서 게시판 CRUD 로직을 처리하도록 구현했습니다. ᵔ  ̫ ᵔ 

- `POST /api/board`: 게시판 생성
- `GET /api/board/{id}`: 게시판 개별 조회
- `GET /api/board`: 게시판 전체 조회
- `PUT /api/board/{id}`: 게시판 수정
- `DELETE /api/board/{id}`: 게시판 삭제

전체 처리 과정은 ~~

1. 클라이언트가 Board API로 HTTP 요청을 보내면
2. `BoardController`가 요청을 받아 요청에 맞는 `BoardService` 메서드 호출
4. `BoardService`가 게시판 생성, 조회, 수정, 삭제 로직을 수행
5. `BoardRepository`가 JPA를 통해 DB에 접근하여 데이터를 저장, 조회, 수정, 삭제
6. `Board` Entity를 `BoardDTO`로 변환
7. `BoardController`가 처리 결과와 HTTP 상태 코드 응답

#### 게시판 생성

- DTO의 `name`으로 새로운 `Board` Entity 생성
- `save()`를 이용해 DB에 저장

#### 게시판 개별 조회 및 삭제

- `findById()`를 이용해 ID에 해당하는 Board 조회
- 해당 게시판이 존재하지 않으면 `404 Not Found` 반환

#### 게시판 전체 조회

- `findAll()`로 모든 게시판 조회
- 각 `Board` Entity를 `BoardDTO`로 변환하여 반환

#### 게시판 수정

- `@Transactional` 안에서 Board Entity의 이름 변경
- JPA의 변경 감지를 통해 수정 사항을 DB에 반영

## 📷 스크린샷 (선택)
<!-- 필요 시 스크린샷을 첨부해주세요. -->
- 게시판 생성
<img width="846" height="953" alt="image" src="https://github.com/user-attachments/assets/88b06500-e7eb-4819-8cc1-568b17902b40" />

- 게시판 전체 조회
<img width="846" height="953" alt="image" src="https://github.com/user-attachments/assets/d23ff0a0-12e3-4229-a496-83a492b73124" />


- 게시판 개별 조회
<img width="846" height="953" alt="image" src="https://github.com/user-attachments/assets/163bcc51-dc3c-42c5-b60b-a06f69ee3bf0" />


- 게시판 수정
<img width="846" height="953" alt="image" src="https://github.com/user-attachments/assets/e28c9348-fbad-4bb5-b5a3-8ea4d2f4a6f4" />
<img width="846" height="953" alt="image" src="https://github.com/user-attachments/assets/5b81f5cb-b0b5-4ea5-8972-130cfadab944" />


- 게시물 추가 후 게시판 삭제
<img width="846" height="953" alt="image" src="https://github.com/user-attachments/assets/25a10238-de69-41f8-bca2-5d7080e9f093" />
<img width="846" height="953" alt="image" src="https://github.com/user-attachments/assets/b88cfd98-58b6-42f7-b2f9-0365d7eafa07" />


- 게시판 삭제 후 게시물 확인 (함께 삭제됨)
<img width="846" height="953" alt="image" src="https://github.com/user-attachments/assets/7fcb1052-c58a-4a67-892f-58e871268eea" />


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

### 레퍼런스
- 백엔드 스프링 4주차 세미나 자료 

### 새로 알게 된 내용

#### `CascadeType` 관련 내용

위의 내용에 함께 정리했습니다 ~~

#### `@Transactional`과 변경 감지

게시판 수정 메서드에서는 조회한 Board의 이름만 변경하고 `save()`를 다시 호출하지 않았다.

```java
@Transactional
public void updateBoard(Long id, BoardDTO boardDTO) {
    Board board = boardRepository.findById(id)
            .orElseThrow(() -> new ResponseStatusException(
                    HttpStatus.NOT_FOUND,
                    "존재하지 않는 게시판입니다."
            ));

    board.setName(boardDTO.getName());
}
```

`@Transactional` 안에서 조회한 Entity는 JPA의 영속성 컨텍스트에서 관리된다. 트랜잭션이 종료될 때 JPA가 Entity의 변경 사항을 확인하고 자동으로 `UPDATE` 쿼리를 실행하는데, 이를 JPA의 변경 감지라고 한다 ! ! 따라서 우리는 따로 저장을 할 필요가 없다 ~~

#### `orElseThrow()`를 이용한 예외 처리

```java
boardRepository.findById(id)
        .orElseThrow(() -> new ResponseStatusException(
                HttpStatus.NOT_FOUND,
                "존재하지 않는 게시판입니다."
        ));
```

`findById()`는 조회 결과가 없을 수 있어 `orElseThrow()`를 사용해 게시판이 존재할 때는 해당 Board를 반환하고, 존재하지 않을 때는 `404 Not Found` 예외를 발생시킬 수 있다.